### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://spglobal-test.visualstudio.com/0b79bdf3-00bf-4f67-a2b4-2ef5423b0864/ae7b913b-e6b5-46ff-9976-5609ce490f23/_apis/work/boardbadge/270ee414-9382-4594-a58a-ee08b8187238)](https://spglobal-test.visualstudio.com/0b79bdf3-00bf-4f67-a2b4-2ef5423b0864/_boards/board/t/ae7b913b-e6b5-46ff-9976-5609ce490f23/Microsoft.RequirementCategory)
 Badge


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#336](https://spglobal-test.visualstudio.com/0b79bdf3-00bf-4f67-a2b4-2ef5423b0864/_workitems/edit/336). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.